### PR TITLE
feat: remove Save As from menu, command palette, and keybinding

### DIFF
--- a/.github/workflows/patch-rebuild.yml
+++ b/.github/workflows/patch-rebuild.yml
@@ -107,20 +107,27 @@ jobs:
 
           # Force build by using repository dispatch with special payload
           # This single dispatch will trigger all OS workflows that listen for this quality
+          # Use jq to properly escape the JSON payload
+          PAYLOAD=$(jq -n \
+            --arg quality "${QUALITY}" \
+            --arg reason "${BUILD_REASON}" \
+            --arg version "${RELEASE_VERSION}" \
+            '{
+              event_type: $quality,
+              client_payload: {
+                quality: $quality,
+                patch_rebuild: true,
+                force_build: true,
+                build_reason: $reason,
+                release_version: $version
+              }
+            }')
+
           curl -X POST \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${GITHUB_TOKEN}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/${{ github.repository }}/dispatches \
-            -d "{
-              \"event_type\": \"${QUALITY}\",
-              \"client_payload\": {
-                \"quality\": \"${QUALITY}\",
-                \"patch_rebuild\": true,
-                \"force_build\": true,
-                \"build_reason\": \"${BUILD_REASON}\",
-                \"release_version\": \"${RELEASE_VERSION}\"
-              }
-            }"
+            -d "${PAYLOAD}"
 
           echo "✅ Triggered all ${QUALITY} platform builds"

--- a/.github/workflows/stable-macos.yml
+++ b/.github/workflows/stable-macos.yml
@@ -43,9 +43,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runner: macos-13
+          - runner: macos-15
             vscode_arch: x64
-          - runner: macos-14
+          - runner: macos-15
             vscode_arch: arm64
 
     steps:

--- a/PATCH_REBUILD_INFO.md
+++ b/PATCH_REBUILD_INFO.md
@@ -1,6 +1,6 @@
 === PATCH REBUILD ===
-**Build Version:** 1.99.24959
-**Base VS Code:** 1.99.2
-**Rebuild Reason:** Added Extensions Back (and updated windows to windows-2022)
-**Build Date:** Fri Jul 25 15:36:42 UTC 2025
-**Commit:** b5985cff763326c126bdb1b80acc552f7829b71d
+**Build Version:** 1.100.00529
+**Base VS Code:** 1.100.0
+**Rebuild Reason:** Remove "Save as"
+**Build Date:** Thu Jan 22 01:25:41 UTC 2026
+**Commit:** ad68f292f1ac88561067f79a213d08dbdd9f7933

--- a/PATCH_REBUILD_INFO.md
+++ b/PATCH_REBUILD_INFO.md
@@ -1,6 +1,6 @@
 === PATCH REBUILD ===
-**Build Version:** 1.100.00529
+**Build Version:** 1.100.00541
 **Base VS Code:** 1.100.0
-**Rebuild Reason:** Remove "Save as"
-**Build Date:** Thu Jan 22 01:25:41 UTC 2026
-**Commit:** ad68f292f1ac88561067f79a213d08dbdd9f7933
+**Rebuild Reason:** Remove save as
+**Build Date:** Thu Jan 22 13:22:21 UTC 2026
+**Commit:** d5a868671a6cb41b765cf93c070f7dce4bc2e6d5

--- a/patches/user/remove-save-as.patch
+++ b/patches/user/remove-save-as.patch
@@ -1,0 +1,53 @@
+diff --git a/src/vs/workbench/contrib/files/browser/fileActions.contribution.ts b/src/vs/workbench/contrib/files/browser/fileActions.contribution.ts
+index 6cd0433..074c7eb 100644
+--- a/src/vs/workbench/contrib/files/browser/fileActions.contribution.ts
++++ b/src/vs/workbench/contrib/files/browser/fileActions.contribution.ts
+@@ -12,3 +12,3 @@ import { KeyMod, KeyCode } from '../../../../base/common/keyCodes.js';
+ import { openWindowCommand, newWindowCommand } from './fileCommands.js';
+-import { COPY_PATH_COMMAND_ID, REVEAL_IN_EXPLORER_COMMAND_ID, OPEN_TO_SIDE_COMMAND_ID, REVERT_FILE_COMMAND_ID, SAVE_FILE_COMMAND_ID, SAVE_FILE_LABEL, SAVE_FILE_AS_COMMAND_ID, SAVE_FILE_AS_LABEL, SAVE_ALL_IN_GROUP_COMMAND_ID, OpenEditorsGroupContext, COMPARE_WITH_SAVED_COMMAND_ID, COMPARE_RESOURCE_COMMAND_ID, SELECT_FOR_COMPARE_COMMAND_ID, ResourceSelectedForCompareContext, OpenEditorsDirtyEditorContext, COMPARE_SELECTED_COMMAND_ID, REMOVE_ROOT_FOLDER_COMMAND_ID, REMOVE_ROOT_FOLDER_LABEL, SAVE_FILES_COMMAND_ID, COPY_RELATIVE_PATH_COMMAND_ID, SAVE_FILE_WITHOUT_FORMATTING_COMMAND_ID, SAVE_FILE_WITHOUT_FORMATTING_LABEL, OpenEditorsReadonlyEditorContext, OPEN_WITH_EXPLORER_COMMAND_ID, NEW_UNTITLED_FILE_COMMAND_ID, NEW_UNTITLED_FILE_LABEL, SAVE_ALL_COMMAND_ID, OpenEditorsSelectedFileOrUntitledContext } from './fileConstants.js';
++import { COPY_PATH_COMMAND_ID, REVEAL_IN_EXPLORER_COMMAND_ID, OPEN_TO_SIDE_COMMAND_ID, REVERT_FILE_COMMAND_ID, SAVE_FILE_COMMAND_ID, SAVE_FILE_LABEL, SAVE_ALL_IN_GROUP_COMMAND_ID, OpenEditorsGroupContext, COMPARE_WITH_SAVED_COMMAND_ID, COMPARE_RESOURCE_COMMAND_ID, SELECT_FOR_COMPARE_COMMAND_ID, ResourceSelectedForCompareContext, OpenEditorsDirtyEditorContext, COMPARE_SELECTED_COMMAND_ID, REMOVE_ROOT_FOLDER_COMMAND_ID, REMOVE_ROOT_FOLDER_LABEL, SAVE_FILES_COMMAND_ID, COPY_RELATIVE_PATH_COMMAND_ID, SAVE_FILE_WITHOUT_FORMATTING_COMMAND_ID, SAVE_FILE_WITHOUT_FORMATTING_LABEL, OpenEditorsReadonlyEditorContext, OPEN_WITH_EXPLORER_COMMAND_ID, NEW_UNTITLED_FILE_COMMAND_ID, NEW_UNTITLED_FILE_LABEL, SAVE_ALL_COMMAND_ID, OpenEditorsSelectedFileOrUntitledContext } from './fileConstants.js';
+ import { CommandsRegistry, ICommandHandler } from '../../../../platform/commands/common/commands.js';
+@@ -260,8 +260,2 @@ appendToCommandPalette({
+ 
+-appendToCommandPalette({
+-	id: SAVE_FILE_AS_COMMAND_ID,
+-	title: SAVE_FILE_AS_LABEL,
+-	category: Categories.File
+-});
+-
+ appendToCommandPalette({
+@@ -696,12 +690,2 @@ MenuRegistry.appendMenuItem(MenuId.MenubarFileMenu, {
+ 
+-MenuRegistry.appendMenuItem(MenuId.MenubarFileMenu, {
+-	group: '4_save',
+-	command: {
+-		id: SAVE_FILE_AS_COMMAND_ID,
+-		title: nls.localize({ key: 'miSaveAs', comment: ['&& denotes a mnemonic'] }, "Save &&As..."),
+-		precondition: ContextKeyExpr.or(ActiveEditorContext, ContextKeyExpr.and(FoldersViewVisibleContext, SidebarFocusContext))
+-	},
+-	order: 2
+-});
+-
+ MenuRegistry.appendMenuItem(MenuId.MenubarFileMenu, {
+diff --git a/src/vs/workbench/contrib/files/browser/fileCommands.ts b/src/vs/workbench/contrib/files/browser/fileCommands.ts
+index 267b609..d2b077b 100644
+--- a/src/vs/workbench/contrib/files/browser/fileCommands.ts
++++ b/src/vs/workbench/contrib/files/browser/fileCommands.ts
+@@ -48,3 +48,3 @@ import { ViewContainerLocation } from '../../../common/views.js';
+ import { IViewsService } from '../../../services/views/common/viewsService.js';
+-import { OPEN_TO_SIDE_COMMAND_ID, COMPARE_WITH_SAVED_COMMAND_ID, SELECT_FOR_COMPARE_COMMAND_ID, ResourceSelectedForCompareContext, COMPARE_SELECTED_COMMAND_ID, COMPARE_RESOURCE_COMMAND_ID, COPY_PATH_COMMAND_ID, COPY_RELATIVE_PATH_COMMAND_ID, REVEAL_IN_EXPLORER_COMMAND_ID, OPEN_WITH_EXPLORER_COMMAND_ID, SAVE_FILE_COMMAND_ID, SAVE_FILE_WITHOUT_FORMATTING_COMMAND_ID, SAVE_FILE_AS_COMMAND_ID, SAVE_ALL_COMMAND_ID, SAVE_ALL_IN_GROUP_COMMAND_ID, SAVE_FILES_COMMAND_ID, REVERT_FILE_COMMAND_ID, REMOVE_ROOT_FOLDER_COMMAND_ID, PREVIOUS_COMPRESSED_FOLDER, NEXT_COMPRESSED_FOLDER, FIRST_COMPRESSED_FOLDER, LAST_COMPRESSED_FOLDER, NEW_UNTITLED_FILE_COMMAND_ID, NEW_UNTITLED_FILE_LABEL, NEW_FILE_COMMAND_ID } from './fileConstants.js';
++import { OPEN_TO_SIDE_COMMAND_ID, COMPARE_WITH_SAVED_COMMAND_ID, SELECT_FOR_COMPARE_COMMAND_ID, ResourceSelectedForCompareContext, COMPARE_SELECTED_COMMAND_ID, COMPARE_RESOURCE_COMMAND_ID, COPY_PATH_COMMAND_ID, COPY_RELATIVE_PATH_COMMAND_ID, REVEAL_IN_EXPLORER_COMMAND_ID, OPEN_WITH_EXPLORER_COMMAND_ID, SAVE_FILE_COMMAND_ID, SAVE_FILE_WITHOUT_FORMATTING_COMMAND_ID, SAVE_ALL_COMMAND_ID, SAVE_ALL_IN_GROUP_COMMAND_ID, SAVE_FILES_COMMAND_ID, REVERT_FILE_COMMAND_ID, REMOVE_ROOT_FOLDER_COMMAND_ID, PREVIOUS_COMPRESSED_FOLDER, NEXT_COMPRESSED_FOLDER, FIRST_COMPRESSED_FOLDER, LAST_COMPRESSED_FOLDER, NEW_UNTITLED_FILE_COMMAND_ID, NEW_UNTITLED_FILE_LABEL, NEW_FILE_COMMAND_ID } from './fileConstants.js';
+ import { IFileDialogService } from '../../../../platform/dialogs/common/dialogs.js';
+@@ -484,12 +484,2 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
+ 
+-KeybindingsRegistry.registerCommandAndKeybindingRule({
+-	id: SAVE_FILE_AS_COMMAND_ID,
+-	weight: KeybindingWeight.WorkbenchContrib,
+-	when: undefined,
+-	primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyS,
+-	handler: accessor => {
+-		return saveSelectedEditors(accessor, { reason: SaveReason.EXPLICIT, saveAs: true });
+-	}
+-});
+-
+ KeybindingsRegistry.registerCommandAndKeybindingRule({


### PR DESCRIPTION
## Summary
- Removes "Save As..." from the File menu
- Removes "File: Save As..." from the command palette
- Removes the Ctrl/Cmd+Shift+S keybinding for Save As

## Test plan
- [x] Build the application with the patch applied
- [x] Verify "Save As" is not in File menu
- [ ] Verify Ctrl/Cmd+Shift+S does nothing
- [x] Verify "Save As" is not in command palette

🤖 Generated with [Claude Code](https://claude.com/claude-code)